### PR TITLE
add a base CellProfiler configuration file to the CellProfiler Deskto…

### DIFF
--- a/cellprofiler/desktop/CellProfilerLocal.cfg
+++ b/cellprofiler/desktop/CellProfilerLocal.cfg
@@ -1,0 +1,5 @@
+PreferencesVersion=1
+Telemetry=0
+Telemetry\ prompt=0
+Colormap=jet_r
+PluginDirectoryCP4=/home/user/CellProfiler-plugins

--- a/cellprofiler/desktop/Dockerfile
+++ b/cellprofiler/desktop/Dockerfile
@@ -1,11 +1,11 @@
-# CellProfiler plugins GitHub page https://github.com/CellProfiler/CellProfiler-plugins) 
+# CellProfiler plugins GitHub page https://github.com/CellProfiler/CellProfiler-plugins)
 # the plug-ins (listed on the page as runcellpose.py, runstardist.py, runimagejscript.py) are
 # CellPose (https://cellpose.readthedocs.io/en/latest/ https://www.cellpose.org/)
 # StartDist (https://github.com/stardist/stardist https://imagej.net/plugins/stardist)
 # ImageJ (https://imagej.nih.gov/ij/)
 # https://cellprofiler-manual.s3.amazonaws.com/CPmanual/RunImageJ.html)
 
-FROM harbor.cyverse.org/vice/xpra/desktop:22.04 
+FROM harbor.cyverse.org/vice/xpra/desktop:22.04
 
 USER root
 
@@ -15,13 +15,13 @@ RUN apt-get update && \
     default-jre \
     default-jdk \
     && \
-    apt-get clean && \ 
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    apt-get clean && \ 
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/ImageJ && \
-    wget https://downloads.imagej.net/fiji/latest/fiji-linux64.zip && \ 
+    wget https://downloads.imagej.net/fiji/latest/fiji-linux64.zip && \
     # unzip .zip file to /opt/ImageJ
     unzip -o fiji-linux64.zip -d /opt/ImageJ  && \
     rm -rf fiji-linux64.zip && \
@@ -34,9 +34,9 @@ RUN apt-get update && \
     python3-pip \
     python3-tk \
     && \
-    apt-get clean && \ 
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    apt-get clean && \ 
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 # set back as `user`
@@ -80,5 +80,6 @@ RUN cd && \
 
 # changes tmux layout while running
 COPY entry.sh /bin
+COPY CellProfilerLocal.cfg /home/user
 RUN echo 'set-option -g status off' >> ~/.tmux.conf
 ENTRYPOINT ["bash", "/bin/entry.sh"]


### PR DESCRIPTION
…p image

This change adds a simple CellProfiler configuration file that instructs CellProfiler Desktop to look for plugins in `/home/user/CellProfiler-plugins`.

The actual change is to add the configuration file and update the Dockerfile to copy it to the correct location in the container. The rest of the changes are inconsequential. My editor is configured to remove trailing whitespace from all lines and to add a trailing newline at the end of the file.

I haven't been able to get this image to build yet, so I'd recommend trying that before merging this PR. I tried building the image both before and after my changes and got the same error both times, so I'm relatively sure that the error isn't related to my change.
